### PR TITLE
feat(auth): adiciona avatar do usuário logado e configura next/image

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,13 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  // outras configs
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -1,0 +1,18 @@
+import Image from "next/image";
+
+interface AvatarProps {
+    image: string;
+    name: string;
+}
+
+export default function Avatar({ image, name }: AvatarProps) {
+    return (
+        <Image
+            width={40}
+            height={40}
+            src={image}
+            alt={name ?? "User avatar"}
+            className="rounded-full"
+        />
+    );
+}

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -6,9 +6,9 @@ import { signIn, signOut, useSession } from "next-auth/react";
 import { FaGithub } from "react-icons/fa";
 import { FiLogOut } from "react-icons/fi";
 import logo from "../../../public/to-do-list.png";
+import Avatar from "../avatar";
 
 export default function Header() {
-    // useSession é client-side, então estamos ok com "use client"
     const { data: session, status } = useSession();
 
     return (
@@ -25,15 +25,18 @@ export default function Header() {
 
             {/* Navegação */}
             <nav className="flex items-center gap-4 text-black">
-                {/* Link Painel de tarefas só para usuários logados */}
-                {session ? (
+                {session?.user && (
                     <>
                         <Link href="/dashboard" className="hover:underline">
                             Painel de tarefas
                         </Link>
                         <span className="text-gray-400">|</span>
+                        <Avatar
+                            image={session.user.image ?? ""}
+                            name={session.user.name ?? "Usuário"}
+                        />
                     </>
-                ) : null}
+                )}
 
                 {/* Login / Logout */}
                 {status === "loading" ? null : session ? (

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,25 +1,26 @@
 // pages/dashboard.tsx
 "use client";
 
-import { useEffect } from "react";
-import { useSession } from "next-auth/react";
+// import { useEffect } from "react";
+import { getSession, useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import Head from "next/head";
+import { GetServerSideProps } from "next";
 
 export default function Dashboard() {
-    const { data: session, status } = useSession();
-    const router = useRouter();
+    // const { data: session, status } = useSession();
+    // const router = useRouter();
 
     // Redireciona para a home se não estiver logado
-    useEffect(() => {
-        if (status === "unauthenticated") {
-            router.push("/");
-        }
-    }, [status, router]);
+    // useEffect(() => {
+    //     if (status === "unauthenticated") {
+    //         router.push("/");
+    //     }
+    // }, [status, router]);
 
-    if (status === "loading") {
-        return <p>Carregando...</p>;
-    }
+    // if (status === "loading") {
+    //     return <p>Carregando...</p>;
+    // }
 
     return (
         <div className="min-h-screen bg-gray-100 flex flex-col items-center">
@@ -54,4 +55,25 @@ export default function Dashboard() {
             </div>
         </div>
     );
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+
+    const session = await getSession({ req })
+
+    console.log(req, session)
+
+    if (!session?.user) {
+        return {
+            redirect: {
+                destination: "/",
+                permanent: false,
+            }
+        }
+    }
+
+    return {
+        props: {},
+    }
+
 }


### PR DESCRIPTION
Este PR adiciona melhorias na exibição do usuário autenticado e configura o next/image para suportar imagens externas.

**Alterações principais:**

**Componente Avatar**

Criado para exibir a imagem do usuário logado.

Recebe image e name como props.

Aplica rounded-full para estilo circular.

**Componente Header**

Exibe o avatar do usuário autenticado via next-auth.

Corrigido uso de session.user.image e session.user.name.

Mantida a navegação condicional (dashboard, login/logout).

**Configuração do next.config.js**

Adicionado suporte ao domínio avatars.githubusercontent.com para exibição correta das imagens do GitHub.

Compatível com remotePatterns (Next >= 13).