### PR TITLE
Remoção do token GitHub do NextAuth e simplificação da sessão

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -20,23 +20,23 @@ export const authOptions: NextAuthOptions = {
   // Chave secreta para criptografia da sessão
   secret: process.env.NEXTAUTH_SECRET,
 
-  // Ativa logs detalhados
-  debug: true,
+  // // Ativa logs detalhados
+  // debug: true,
 
-  // Configurações da sessão
-  session: {
-    strategy: "jwt", // Use JWT para sessões
-  },
+  // // Configurações da sessão
+  // session: {
+  //   strategy: "jwt", // Use JWT para sessões
+  // },
 
-  // Callbacks opcionais podem ser adicionados aqui
-  callbacks: {
-    async jwt({ token }) {
-      return token;
-    },
-    async session({ session, token }) {
-      return session;
-    },
-  },
+  // // Callbacks opcionais podem ser adicionados aqui
+  // callbacks: {
+  //   async jwt({ token }) {
+  //     return token;
+  //   },
+  //   async session({ session, token }) {
+  //     return session;
+  //   },
+  // },
 };
 
 export default NextAuth(authOptions);


### PR DESCRIPTION
Este PR realiza as seguintes alterações na configuração do NextAuth:

Removeu a estratégia JWT e os callbacks personalizados, evitando o armazenamento do token do GitHub na sessão.

Mantém a autenticação via GitHub funcional, permitindo login e logout normalmente.

Simplifica a configuração do NextAuth, usando comportamento padrão com cookies de sessão.

A sessão no frontend agora contém apenas informações básicas do usuário (name, email, image) sem expor o token do provedor, aumentando a segurança.