### PR TITLE
Implementa a funcionalidade de exclusão de comentários em tarefas

### DIFF
--- a/src/pages/task/[id].tsx
+++ b/src/pages/task/[id].tsx
@@ -12,7 +12,8 @@ import {
     getDoc,
     addDoc,
     getDocs,
-    orderBy
+    orderBy,
+    deleteDoc
 
 } from 'firebase/firestore';
 import { Textarea } from '@/components/form';
@@ -81,9 +82,16 @@ export default function Task({ item, allComments }: TaskProps) {
     }
 
     async function handleDeleteComment(id: string) {
-        // const docRef = doc(db, "comments", id);
-        // await docRef.delete();
-        // setComments(comments.filter((item) => item.id !== id));
+        try {
+            const docRef = doc(db, "comments", id);
+            await deleteDoc(docRef);
+
+            // Filtra todos os comentários que NÃO têm o id deletado
+            setComments(prev => prev.filter(comment => comment.id !== id));
+
+        } catch (error) {
+            console.error("Erro ao deletar comentário:", error);
+        }
     }
 
     return (


### PR DESCRIPTION
Implementa a funcionalidade de exclusão de comentários em tarefas. Usuários podem remover comentários que eles próprios adicionaram.

### Alterações principais
- Adicionada a função `handleDeleteComment` para deletar comentários no Firebase.
- Atualização do estado local `comments` usando `filter`, garantindo que o array de comentários seja atualizado imediatamente após a exclusão.
- Botão de delete (`<FaTrash />`) visível apenas para o autor do comentário.
- Corrige erro de TypeScript relacionado ao tipo do estado ao deletar comentários.

### Comportamento esperado
1. Usuário logado clica no ícone de lixeira ao lado de seu comentário.
2. O comentário é removido do Firebase.
3. A lista de comentários na interface é atualizada sem reload da página.

### Observações
- A exclusão só é permitida para comentários do usuário logado.
- Erros na exclusão são registrados no console (`console.error`).
