### PR TITLE
feat: adicionar getStaticProps para contar tarefas e comentários

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -43,7 +43,7 @@ export default function Home({ posts, comments }: HomeProps) {
   );
 }
 
-export const getServerSideProps: GetStaticProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
 
   const tarefasRef = collection(db, "tarefas");
   const commentsRef = collection(db, "comments");


### PR DESCRIPTION
Corrige a implementação da função de carregamento de dados da página inicial, ajustando a diferença entre `getServerSideProps` e `getStaticProps` para evitar erro 500 na Vercel.

### Alterações principais
- Corrigida a função de carregamento de dados para usar corretamente `getStaticProps` em vez de `getServerSideProps`.
- Removida a propriedade `revalidate` de `getServerSideProps`, que causava erro no deploy.
- Dados de tarefas (`posts`) e comentários (`comments`) agora são carregados corretamente e suportam Incremental Static Regeneration com `revalidate: 60`.

### Comportamento esperado
- Página inicial exibe corretamente a contagem de tarefas e comentários.
- O erro 500 na Vercel foi corrigido.
- Dados estáticos são atualizados a cada 60 segundos sem rebuild completo da aplicação.

### Observações
- Ajuste necessário para compatibilidade com Next.js e boas práticas de ISR.
