### PR TITLE
removendo filtro where da query de tarefas

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -48,7 +48,7 @@ export default function Dashboard({ user }: HomeProps) {
             const q = query(
                 tarefasRef,
                 orderBy("created", "desc"),
-                where("email", "==", user?.email),
+                // where("email", "==", user?.email),
 
             )
 


### PR DESCRIPTION
Este PR remove o filtro baseado em email na query de tarefas, permitindo listar todas as tarefas de forma global, ordenadas pela data de criação (desc).