### PR TITLE
feat: exibir botão de remoção apenas para o criador da tarefa

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -180,14 +180,15 @@ export default function Dashboard({ user }: HomeProps) {
                                         item.tarefa
                                     )}
                                 </p>
-
-                                <button
-                                    className="text-red-500 hover:text-red-700 transition"
-                                    aria-label="Remover tarefa"
-                                    onClick={() => handleDeleteTask(item.id)}
-                                >
-                                    <FaTrash size={16} />
-                                </button>
+                                {item?.email === user?.email && (
+                                    <button
+                                        className="text-red-500 hover:text-red-700 transition"
+                                        aria-label="Remover tarefa"
+                                        onClick={() => handleDeleteTask(item.id)}
+                                    >
+                                        <FaTrash size={16} />
+                                    </button>
+                                )}
                             </div>
 
                         </li>


### PR DESCRIPTION
Este PR adiciona uma regra de segurança na interface para que o botão de exclusão da tarefa só seja exibido quando o usuário logado for o criador da tarefa.

**Alterações realizadas:**

- Condicional {item?.email === user?.email && (...)} adicionada.

- Garante que apenas o criador possa visualizar e acionar o botão de exclusão.